### PR TITLE
Add callers to the pile-up when a QSO is done

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -289,8 +289,8 @@ begin
   //the stations heard my CQ and want to call
   if (not (RunMode in [rmSingle, RmHst])) then
     if (msgCQ in Me.Msg) or
-       ((QsoList <> nil) and (msgTU in Me.Msg) and (msgMyCall in Me.Msg))then
-    for i:=1 to RndPoisson(Activity / 2) do Stations.AddCaller;
+       ((QsoList <> nil) and ((msgTU in Me.Msg) or (msgMyCall in Me.Msg)))then
+    for i:=1 to RndPoisson(Activity / 2) - DxCount do Stations.AddCaller;
 
   //tell callers that I finished sending
   for i:=Stations.Count-1 downto 0 do


### PR DESCRIPTION
Formally, no caller was added to a QSO was done, and hitting F1 several times in a row was adding too many callers regarding the activity setting.

With this mod:

1/ New callers may be added once a QSO is entered.
2/ The total number of callers is always respecting the activity setting